### PR TITLE
DATA-24 - Adding additional fields to report - patch-1

### DIFF
--- a/openedx_proversity_reports/reports/last_page_accessed.py
+++ b/openedx_proversity_reports/reports/last_page_accessed.py
@@ -54,6 +54,7 @@ def get_last_page_accessed_data(course_list):
                 continue
             last_completed_child_position = BlockCompletion.get_latest_block_completed(user, course_key)
             parent_tree_name = ''
+            vertical_block_id = ''
 
             if last_completed_child_position:
                 vertical_blocks = blocks.topological_traversal(


### PR DESCRIPTION
## Description:

This PR assigns 'vertical_block_id' to empty when a course block is deleted and the Blockcompletion model saves that removed block.

## Reviewers:

- [ ] @andrey-canon 