### PR TITLE
Change the API endpoints functionality.

### DIFF
--- a/openedx_proversity_reports/api/v0/urls.py
+++ b/openedx_proversity_reports/api/v0/urls.py
@@ -5,35 +5,19 @@ from django.conf.urls import url
 
 from . import views
 
+REPORT_NAME_PATTERN = r'(?P<report_name>(generate)+[a-z-]+)'
+
 urlpatterns = [
     url(
-        r'^generate-completion-report$',
-        views.GenerateCompletionReportView.as_view(),
-        name='generate-completion-report'
+        r'^{report_name_pattern}$'.format(
+            report_name_pattern=REPORT_NAME_PATTERN,
+        ),
+        views.GenerateReportView.as_view(),
+        name='generate-report-view'
     ),
     url(
-        r'^completion-report-data$',
-        views.CompletionReportView.as_view(),
-        name='completion-report-data'
-    ),
-    url(
-        r'^generate-last-page-accessed-report$',
-        views.GenerateLastPageReportView.as_view(),
-        name='generate-last-page-accessed-report'
-    ),
-    url(
-        r'^last-page-accessed-report-data$',
-        views.LastPageReportView.as_view(),
-        name='last-page-accessed-report-data'
-    ),
-    url(
-        r'^generate-time-spent-report$',
-        views.GenerateTimeSpentReportView.as_view(),
-        name='generate-time-spent-report'
-    ),
-    url(
-        r'^time-spent-report-data$',
-        views.TimeSpentReportView.as_view(),
-        name='time-spent-report-data'
+        r'^get-report-data$',
+        views.GetReportView.as_view(),
+        name='get-report-data'
     ),
 ]

--- a/openedx_proversity_reports/apps.py
+++ b/openedx_proversity_reports/apps.py
@@ -28,3 +28,10 @@ class OpenEdxProversityReportsConfig(AppConfig):
             },
         },
     }
+
+    def ready(self):
+        """
+        The line below allows tasks defined in this app to be included by celery workers.
+        https://docs.djangoproject.com/en/1.8/ref/applications/#methods
+        """
+        from .tasks import *  # pylint: disable=unused-variable, wildcard-import

--- a/openedx_proversity_reports/settings/common.py
+++ b/openedx_proversity_reports/settings/common.py
@@ -39,13 +39,19 @@ def plugin_settings(settings):
     Set of plugin settings used by the Open Edx platform.
     More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
+    # pylint: disable=line-too-long
     settings.OPR_COURSE_BLOCKS = 'openedx_proversity_reports.edxapp_wrapper.backends.course_blocks_i_v1'
     settings.OPR_COURSE_COHORT = 'openedx_proversity_reports.edxapp_wrapper.backends.course_cohort_i_v1'
     settings.OPR_COURSE_TEAMS = 'openedx_proversity_reports.edxapp_wrapper.backends.course_teams_i_v1'
-    settings.OPR_EDX_REST_FRAMEWORK_EXTENSIONS = 'openedx_proversity_reports.edxapp_wrapper.backends.edx_rest_framework_extensions_i_v1'  # pylint: disable=line-too-long
+    settings.OPR_EDX_REST_FRAMEWORK_EXTENSIONS = 'openedx_proversity_reports.edxapp_wrapper.backends.edx_rest_framework_extensions_i_v1'
     settings.OPR_MODULESTORE = 'openedx_proversity_reports.edxapp_wrapper.backends.modulestore_i_v1'
     settings.OPR_OPENEDX_PERMISSIONS = 'openedx_proversity_reports.edxapp_wrapper.backends.openedx_permissions_i_v1'
     settings.OPR_STUDENT_LIBRARY = 'openedx_proversity_reports.edxapp_wrapper.backends.student_i_v1'
     settings.OPR_SUPPORTED_FIELDS = 'openedx_proversity_reports.edxapp_wrapper.backends.supported_fields_i_v1'
     settings.OPR_GOOGLE_ANALYTICS_CREDENTIALS = {}
     settings.OPR_GOOGLE_ANALYTICS_VIEW_ID = ''
+    settings.OPR_SUPPORTED_TASKS = [
+        'generate_completion_report',
+        'generate_last_page_accessed_report',
+        'generate_time_spent_report',
+    ]

--- a/openedx_proversity_reports/settings/production.py
+++ b/openedx_proversity_reports/settings/production.py
@@ -57,3 +57,8 @@ def plugin_settings(settings):
         'OPR_GOOGLE_ANALYTICS_CREDENTIALS',
         settings.OPR_GOOGLE_ANALYTICS_CREDENTIALS
     )
+
+    settings.OPR_SUPPORTED_TASKS = getattr(settings, 'ENV_TOKENS', {}).get(
+        'OPR_SUPPORTED_TASKS',
+        settings.OPR_SUPPORTED_TASKS
+    )

--- a/openedx_proversity_reports/tasks.py
+++ b/openedx_proversity_reports/tasks.py
@@ -14,12 +14,17 @@ from openedx_proversity_reports.reports.time_spent_report import get_time_spent_
 from openedx_proversity_reports.utils import generate_report_as_list, get_root_block
 
 
+BLOCK_DEFAULT_REPORT_FILTER = ['vertical']
+
+
 @task(default_retry_delay=5, max_retries=5)  # pylint: disable=not-callable
-def generate_completion_report(courses, block_report_filter):
+def generate_completion_report(courses, *args, **kwargs):
     """
     Return the completion data for the given courses
     """
+    block_report_filter = kwargs.get('block_report_filter', BLOCK_DEFAULT_REPORT_FILTER)
     data = {}
+
     for course_id in courses:
         try:
             course_key = CourseKey.from_string(course_id)
@@ -46,7 +51,7 @@ def generate_completion_report(courses, block_report_filter):
 
 
 @task(default_retry_delay=5, max_retries=5)  # pylint: disable=not-callable
-def generate_last_page_accessed_report(courses):
+def generate_last_page_accessed_report(courses, *args, **kwargs):
     """
     Return the last page accessed data for the given courses.
 
@@ -68,7 +73,7 @@ def generate_last_page_accessed_report(courses):
 
 
 @task(default_retry_delay=5, max_retries=5)  # pylint: disable=not-callable
-def generate_time_spent_report(courses):
+def generate_time_spent_report(courses, *args, **kwargs):
     """
     Return the time spent data for the given courses.
 

--- a/openedx_proversity_reports/utils.py
+++ b/openedx_proversity_reports/utils.py
@@ -4,6 +4,7 @@
 Utils file for Openedx Proversity Reports.
 """
 import copy
+from importlib import import_module
 
 from completion.models import BlockCompletion
 from django.contrib.auth.models import User
@@ -255,3 +256,16 @@ def get_user_role(user, course_key):
         user_role = '-'.join([getattr(role, 'role', '') for role in user_course_role])
 
     return user_role
+
+
+def get_attribute_from_module(module, attribute_name):
+    """
+    Return the attribute for the given module path and attribute name.
+     Args:
+        module: String (Module path).
+        attribute_name: String (Module attribute).
+    Returns:
+        Module Attribute.
+    """
+    module = import_module(module)
+    return getattr(module, attribute_name, None)


### PR DESCRIPTION
## Description:

This PR changes the API endpoints functionality, in order to enable just two API endpoints, one for generate the request report and other one for get the report data by task id.

The supported task will be defined by OPR_SUPPORTED_TASKS setting.

## Reviewers:

- [ ] @diegomillan 
- [ ] @andrey-canon 