### PR TITLE
DATA-40 - Updating the activity completion report.

### DIFF
--- a/openedx_proversity_reports/reports/activity_completion_report.py
+++ b/openedx_proversity_reports/reports/activity_completion_report.py
@@ -1,14 +1,15 @@
 """
 Activity completion report module.
 """
+from __future__ import division
 import logging
 
-from openedx_proversity_reports.edxapp_wrapper.get_completion_models import \
-    get_block_completion_model
 from django.core.exceptions import ObjectDoesNotExist
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.locator import BlockUsageLocator
 
+from openedx_proversity_reports.edxapp_wrapper.get_block_structure_library import get_course_in_cache
+from openedx_proversity_reports.edxapp_wrapper.get_completion_models import get_block_completion_model
 from openedx_proversity_reports.edxapp_wrapper.get_courseware_library import get_course_by_id
 from openedx_proversity_reports.edxapp_wrapper.get_modulestore import (
     get_modulestore,
@@ -25,11 +26,37 @@ class GenerateCompletionReport(object):
     Class to generate the activity completion report.
     """
 
-    def __init__(self, users, course_key, required_block_ids):
+    def __init__(self, users, course_key, required_block_ids, block_types, passing_score):
         self.users = users
         self.course_key = course_key
         self.course = get_course_by_id(self.course_key)
+        self.required_block_types = block_types
         self.required_block_ids = self.get_course_required_block_ids(required_block_ids)
+        self.passing_score = passing_score
+
+
+    @property
+    def matching_blocks_by_type(self):
+        """
+        Returns blocks matching by self.block_type_filter.
+        """
+        block_structure = get_course_in_cache(self.course_key)
+        matching_blocks = block_structure.topological_traversal(
+            filter_func=self.block_type_filter,
+            yield_descendants_of_unyielded=True,
+        )
+
+        return list(matching_blocks)
+
+
+    def block_type_filter(self, block_item):
+        """
+        Returns True if the block type exists in the self.required_block_types otherwise False.
+
+        Args:
+            block_item: Course block item to be matched.
+        """
+        return True if block_item.block_type in self.required_block_types else False
 
 
     def generate_report_data(self):
@@ -45,6 +72,10 @@ class GenerateCompletionReport(object):
             completed_activities = self.get_completed_activities(user)
             last_login = user.last_login
             display_last_login = None
+            user_enrollment = user.courseenrollment_set.get(
+                course_id=self.course_key,
+            )
+
 
             # Last login could not be defined for a user.
             if last_login:
@@ -57,14 +88,22 @@ class GenerateCompletionReport(object):
                 'email': user.email,
                 'first_login': user.date_joined.strftime('%Y/%m/%d %H:%M:%S'),
                 'last_login': display_last_login,
-                'completed_activities': get_count_required_completed_activities(required_ids, completed_activities),
+                'completed_activities': len(filter_completed_blocks(
+                    required_ids,
+                    completed_activities,
+                )),
+                'course_is_complete': is_course_activities_complete(
+                    required_ids,
+                    completed_activities,
+                    self.passing_score,
+                ),
+                'student_enrollment_id': user_enrollment.id,
             }
 
             for index, item in enumerate(required_ids, 1):
                 try:
-                    locator = BlockUsageLocator.from_string(item)
-                    state = is_activity_completed(locator.block_id, completed_activities)
-                    block = get_modulestore().get_item(locator)
+                    state = is_activity_completed(item.block_id, completed_activities)
+                    block = get_modulestore().get_item(item)
                     total_activities += 1
                 except item_not_found_error() as item_error:
                     logger.warn(
@@ -77,8 +116,8 @@ class GenerateCompletionReport(object):
                     continue
 
                 data.update({
-                    'Required Activity {}'.format(index): state,
-                    'Required Activity {} Name'.format(index): block.display_name,
+                    'required_activity_{}'.format(index): state,
+                    'required_activity_{}_name'.format(index): block.display_name,
                 })
 
             data.update({
@@ -102,21 +141,33 @@ class GenerateCompletionReport(object):
         Filters the required_block_ids list, and returns
         only the required block ids that belong to the same course key.
 
+        If the self.matching_blocks_by_type is set, it returns a mix with required_block_ids
+        which exists in self.matching_blocks_by_type too.
+
+        If required_block_ids is not provided, it returns just the self.matching_blocks_by_type list.
+
         Args:
             required_block_ids: List of the block location ids.
         Returns:
-            required_course_block_ids:
-                List containing only the block location ids,
-                that belong to the same course key.
+            required_course_block_ids: List containing only the BlockUsageLocator items.
         """
+        matching_blocks_by_type = self.matching_blocks_by_type
+
+        if not required_block_ids:
+            return matching_blocks_by_type
+
         required_course_block_ids = []
 
         for required_block_id in required_block_ids:
             try:
                 block_locator = BlockUsageLocator.from_string(required_block_id)
 
-                if block_locator.course_key == self.course_key:
-                    required_course_block_ids.append(required_block_id)
+                if not matching_blocks_by_type and block_locator.course_key == self.course_key:
+                    required_course_block_ids.append(block_locator)
+                    continue
+
+                if block_locator in matching_blocks_by_type:
+                    required_course_block_ids.append(block_locator)
             except InvalidKeyError:
                 continue
 
@@ -134,22 +185,6 @@ def is_activity_completed(block_id, activities):
     return 'not_completed'
 
 
-def get_count_required_completed_activities(required_ids, activities):
-    """
-    Returns a counter with the number of required activities completed.
-    """
-    required_activity_count = 0
-
-    for required_id in required_ids:
-        required_block = BlockUsageLocator.from_string(required_id)
-
-        for activity in activities:
-            if required_block.block_id == activity.block_id:
-                required_activity_count += 1
-
-    return required_activity_count
-
-
 def get_first_and_last_name(full_name):
     """
     Takes the argument full_name a returns a list with the first name and last name.
@@ -162,3 +197,52 @@ def get_first_and_last_name(full_name):
         if len(result) == 2:
             return result
         return [full_name, full_name]
+
+
+def is_course_activities_complete(course_blocks, completed_activities, passing_score):
+    """
+    Verifies if the course is complete depending on the total of the provided course_blocks,
+    divided by the total of completed blocks if it is greater than or equal to passing_score.
+
+    PASS = ( COUNT OF BLOCKS COMPLETED / COUNT OF TOTAL COURSE BLOCKS ) >= passing_score
+
+    Args:
+        course_blocks: All the required BlockUsageLocator items.
+        completed_activities: All the BlockUsageLocator completion items per user.
+        passing_score: Percentage of the completed activities.
+    Retunrs:
+        Boolean: True if the user has completed the course activities
+            depending on the calculation, if not False.
+    """
+    required_completed_activities = filter_completed_blocks(
+        course_blocks,
+        completed_activities,
+    )
+
+    if not required_completed_activities:
+        return False
+
+    return (len(required_completed_activities) / len(course_blocks)) >= passing_score
+
+
+def filter_completed_blocks(required_blocks, completed_activities):
+    """
+    Filters the activities completed by the required blocks.
+    This is in order to get only the completed activities that exists in the
+    required blocks.
+
+    Args:
+        required_blocks: All the requested BlockUsageLocator items.
+        completed_activities: All the completed BlockUsageLocator items per user.
+    Returns:
+        required_block_filter_list: List with only the completed activities that exists
+            in the required_blocks list.
+    """
+    required_block_filter_list = []
+
+    for activity_block in required_blocks:
+        for block_completed in completed_activities:
+            if block_completed.block_id == activity_block.block_id:
+                required_block_filter_list.append(block_completed)
+
+    return required_block_filter_list

--- a/openedx_proversity_reports/serializers.py
+++ b/openedx_proversity_reports/serializers.py
@@ -31,3 +31,27 @@ class SalesforceContactIdSerializer(serializers.Serializer):
     user_id = serializers.IntegerField()
     contact_id = serializers.CharField(max_length=60)
     contact_id_source = serializers.CharField(required=False, max_length=60)
+
+
+class ActivityCompletionReportSerializer(serializers.Serializer):
+    """
+    Serializer for the activity completion report.
+    """
+    required_activity_ids = serializers.ListField(
+        child=serializers.CharField(),
+        allow_empty=True,
+        required=False,
+    )
+    block_types = serializers.ListField(
+        child=serializers.CharField(),
+        allow_empty=True,
+        required=False,
+    )
+    passing_score = serializers.DecimalField(
+        max_digits=3,
+        decimal_places=2,
+        coerce_to_string=False,
+        max_value=1,
+        min_value=0,
+        required=False,
+    )


### PR DESCRIPTION
## Description:

This PR updates the activity completion report to get the activities through required_activity_ids that contains the block ids that must be processed, or through the new request field called: block_types that contains a list of the block types that must be processed.
It also includes a new request parameter called: passing_score which is the percentage to calculate if the user has approved the course between the total of the processed activities and the completed activities.

Now you can get the activities by required id or block type.

## Notes:

The GetReportView view has been improved in order to return the correct status code and validation message from the task.

In order to work on a Ginkgo-Hawthorn instance you must setting up these settings as:

OPR_EDX_REST_FRAMEWORK_EXTENSIONS = 'openedx_proversity_reports.edxapp_wrapper.backends.edx_rest_framework_extensions_g_v1'
OPR_COMPLETION_MODELS = 'openedx_proversity_reports.edxapp_wrapper.backends.completion_models_g_v1'

## Reviewers:

- [ ] @andrey-canon 
- [ ] @diegomillan 