### PR TITLE
Adding backend for the last login report.

### DIFF
--- a/openedx_proversity_reports/reports/last_login_report.py
+++ b/openedx_proversity_reports/reports/last_login_report.py
@@ -1,0 +1,52 @@
+"""
+Last login report backend.
+"""
+import logging
+
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from openedx_proversity_reports.edxapp_wrapper.get_student_library import get_course_enrollment
+
+
+LOG = logging.getLogger(__name__)
+
+
+class LastLoginReport(object):
+    """
+    Last login report Class.
+    """
+
+    def __init__(self, course_id):
+        try:
+            self.course_key = CourseKey.from_string(course_id)
+        except InvalidKeyError:
+            message = 'Invalid course_id: {} value for last login report'.format(course_id)
+            LOG.error(message)
+            raise InvalidKeyError(course_id, message)
+
+    def generate_report_data(self, **kwargs):
+        """
+        Return a List with the information of the last login of the enrolled users.
+
+        kwargs:
+            date: Contains the python date format for the last login value.
+        Returns:
+            List: Containing the users enrolled in the course and their information.
+        """
+        report_data = []
+        course_enrollments = get_course_enrollment().objects.filter(course_id=self.course_key)
+        date_format = kwargs.get('date_format', '%Y-%m-%d')
+
+        for enrollment in course_enrollments:
+            user_last_login_date = enrollment.user.last_login.strftime(date_format)
+            date_of_registration = enrollment.user.date_joined.strftime(date_format)
+
+            report_data.append({
+                'username': enrollment.user.username,
+                'email': enrollment.user.email,
+                'last_login_date': user_last_login_date,
+                'date_of_registration': date_of_registration,
+            })
+
+        return report_data

--- a/openedx_proversity_reports/settings/common.py
+++ b/openedx_proversity_reports/settings/common.py
@@ -65,6 +65,7 @@ def plugin_settings(settings):
         'generate_enrollment_report',
         'generate_activity_completion_report',
         'generate_time_spent_per_user_report',
+        'generate_last_login_report',
     ]
     settings.OPR_TIME_BETWEEN_SESSIONS = 5  # This value is in minutes.
     settings.OPR_COURSE_DETAILS = 'openedx_proversity_reports.edxapp_wrapper.backends.course_details_g_v1'

--- a/openedx_proversity_reports/tasks.py
+++ b/openedx_proversity_reports/tasks.py
@@ -21,6 +21,7 @@ from openedx_proversity_reports.reports.last_page_accessed import (
     get_last_page_accessed_data,
 )
 from openedx_proversity_reports.reports.learning_tracker_report import LearningTrackerReport
+from openedx_proversity_reports.reports.last_login_report import LastLoginReport
 from openedx_proversity_reports.reports.time_spent_report import get_time_spent_report_data
 from openedx_proversity_reports.reports.time_spent_report_per_user import GenerateTimeSpentPerUserReport
 from openedx_proversity_reports.serializers import ActivityCompletionReportSerializer
@@ -268,3 +269,24 @@ def enrollment_per_site_report_task(*args, **kwargs):
         'course': course_object.display_name if course_object else '',
         'data': report_data,
     }
+
+
+@task(default_retry_delay=5, max_retries=5)  # pylint: disable=not-callable
+def generate_last_login_report(courses, *args, **kwargs):
+    """
+    Return the last login data for the given courses.
+
+    Args:
+        courses: Course ids list.
+    Returns:
+        Dict with the last login data for each course.
+    """
+    data = {}
+
+    for course in courses:
+        try:
+            data[course] = LastLoginReport(course).generate_report_data(**kwargs)
+        except InvalidKeyError:
+            data[course] = ['Invalid course id value.']
+
+    return data


### PR DESCRIPTION
### Description:

This PR adds the last login report backend to the avalaible reports for the plugin.

This report was developed by @Squirrel18  for a previous version of the plugin and was tested for Gingko and Hawthorn. I tested it in Ironwood this time and works correctly.

For now, the last login report only works with version v0 of the backend.

### Reviewers:

- [ ] @Squirrel18 

- [ ] @diegomillan 

- [ ] @luismorenolopera 